### PR TITLE
Add enum & knownValues type hints

### DIFF
--- a/.changeset/enum-known-values-type-hints.md
+++ b/.changeset/enum-known-values-type-hints.md
@@ -1,0 +1,7 @@
+---
+"prototypey": patch
+---
+
+Add type-level inference for `enum` and `knownValues` on string fields.
+
+Strings with `enum` now infer as a union of the literal values; strings with `knownValues` infer as the literal union widened with `string & {}` so unlisted values are still accepted.

--- a/packages/prototypey/core/infer.ts
+++ b/packages/prototypey/core/infer.ts
@@ -26,7 +26,15 @@ type InferType<T> = T extends { type: "record" }
 											: T extends { type: "integer" }
 												? number
 												: T extends { type: "string" }
-													? string
+													? T extends {
+															enum: readonly (infer E extends string)[];
+														}
+														? E
+														: T extends {
+																	knownValues: readonly (infer K extends string)[];
+																}
+															? K | (string & {})
+															: string
 													: T extends { type: "bytes" }
 														? Uint8Array
 														: T extends { type: "cid-link" }

--- a/packages/prototypey/core/infer.ts
+++ b/packages/prototypey/core/infer.ts
@@ -31,8 +31,9 @@ type InferType<T> = T extends { type: "record" }
 														}
 														? E
 														: T extends {
-																	knownValues: readonly (infer K extends string)[];
-																}
+																	knownValues: readonly (infer K extends
+																		string)[];
+															  }
 															? K | (string & {})
 															: string
 													: T extends { type: "bytes" }

--- a/packages/prototypey/core/lib.ts
+++ b/packages/prototypey/core/lib.ts
@@ -578,7 +578,7 @@ export const lx = {
 	 * Creates a string type with optional format, length, and value constraints.
 	 * @see https://atproto.com/specs/lexicon#string
 	 */
-	string<T extends StringOptions>(options?: T): T & { type: "string" } {
+	string<const T extends StringOptions>(options?: T): T & { type: "string" } {
 		return {
 			type: "string",
 			...options,

--- a/packages/prototypey/core/tests/infer.test.ts
+++ b/packages/prototypey/core/tests/infer.test.ts
@@ -69,6 +69,109 @@ test("InferType handles string primitive", () => {
 }`);
 });
 
+test("InferType handles string with enum constraint", () => {
+	const lexicon = lx.lexicon("test.stringEnum", {
+		main: lx.object({
+			status: lx.string({ enum: ["active", "inactive", "pending"] }),
+		}),
+	});
+
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "test.stringEnum"
+  status?: "active" | "inactive" | "pending" | undefined
+}`);
+});
+
+test("InferType handles string with knownValues hint", () => {
+	const lexicon = lx.lexicon("test.stringKnownValues", {
+		main: lx.object({
+			lang: lx.string({
+				knownValues: ["en", "fr", "de"],
+			}),
+		}),
+	});
+
+	// attest expands all of `strings` methods here, which we need
+	// because atproto's `knownValues` are an open set.
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "test.stringKnownValues"
+  lang?:
+    | "en"
+    | "fr"
+    | "de"
+    | {
+        readonly [x: number]: string
+        toString: () => string
+        charAt: {}
+        charCodeAt: {}
+        concat: {}
+        indexOf: {}
+        lastIndexOf: {}
+        localeCompare: {}
+        match: {}
+        replace: {}
+        search: {}
+        slice: {}
+        split: {}
+        substring: {}
+        toLowerCase: () => string
+        toLocaleLowerCase: {}
+        toUpperCase: () => string
+        toLocaleUpperCase: {}
+        trim: () => string
+        readonly length: number
+        substr: {}
+        valueOf: () => string
+        codePointAt: {}
+        includes: {}
+        endsWith: {}
+        normalize: {}
+        repeat: {}
+        startsWith: {}
+        anchor: {}
+        big: () => string
+        blink: () => string
+        bold: () => string
+        fixed: () => string
+        fontcolor: {}
+        fontsize: {}
+        italics: () => string
+        link: {}
+        small: () => string
+        strike: () => string
+        sub: () => string
+        sup: () => string
+        padStart: {}
+        padEnd: {}
+        trimEnd: () => string
+        trimStart: () => string
+        trimLeft: () => string
+        trimRight: () => string
+        matchAll: {}
+        replaceAll: {}
+        at: {}
+        [Symbol.iterator]: () => StringIterator<string>
+      }
+    | undefined
+}`);
+});
+
+test("InferType handles required string with enum", () => {
+	const lexicon = lx.lexicon("test.requiredEnum", {
+		main: lx.object({
+			role: lx.string({
+				required: true,
+				enum: ["admin", "user", "guest"],
+			}),
+		}),
+	});
+
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "test.requiredEnum"
+  role: "user" | "admin" | "guest"
+}`);
+});
+
 test("InferType handles integer primitive", () => {
 	const lexicon = lx.lexicon("test.integer", {
 		main: lx.object({


### PR DESCRIPTION
Hey Tyler, I thought this might be useful; it adds type hints for enum values & knownValues on strings.

<img width="530" height="360" alt="An IDE showing autocomplete for an atproto 'knownValues' key" src="https://github.com/user-attachments/assets/8b811349-3e4f-4265-a5f9-88f6d7751742" />
