### PR TITLE
Add type-level inference for query, procedure, and subscription

### DIFF
--- a/.changeset/query-procedure-subscription-type-hints.md
+++ b/.changeset/query-procedure-subscription-type-hints.md
@@ -1,0 +1,31 @@
+---
+"prototypey": minor
+---
+
+Add type-level inference for `query`, `procedure`, and `subscription` lexicon types.
+
+The `~infer` type on a lexicon now resolves `parameters`, `input`, `output`, and `message` bodies into the shapes you'd expect, so you can pull request/response types directly off the schema instead of hand-writing them.
+
+```ts
+const getUser = lx.lexicon("com.example.getUser", {
+	main: lx.query({
+		parameters: lx.params({
+			did: lx.string({ required: true, format: "did" }),
+		}),
+		output: {
+			encoding: "application/json",
+			schema: lx.object({
+				name: lx.string({ required: true }),
+				bio: lx.string(),
+			}),
+		},
+	}),
+});
+
+type GetUser = (typeof getUser)["~infer"];
+// {
+//   $type: "com.example.getUser"
+//   parameters: { did: string }
+//   output: { name: string; bio?: string | undefined }
+// }
+```

--- a/packages/prototypey/core/infer.ts
+++ b/packages/prototypey/core/infer.ts
@@ -17,46 +17,52 @@ type InferPropertyType<T> = T extends { type: "object" }
 
 type InferType<T> = T extends { type: "record" }
 	? InferRecord<T>
-	: T extends { type: "object" }
-		? InferObject<T>
-		: T extends { type: "array" }
-			? InferArray<T>
-			: T extends { type: "params" }
-				? InferParams<T>
-				: T extends { type: "permission-set" }
-					? InferPermissionSet<T>
-					: T extends { type: "union" }
-						? InferUnion<T>
-						: T extends { type: "token" }
-							? InferToken<T>
-							: T extends { type: "ref" }
-								? InferRef<T>
-								: T extends { type: "unknown" }
-									? unknown
-									: T extends { type: "null" }
-										? null
-										: T extends { type: "boolean" }
-											? boolean
-											: T extends { type: "integer" }
-												? number
-												: T extends { type: "string" }
-													? T extends {
-															enum: readonly (infer E extends string)[];
-														}
-														? E
-														: T extends {
-																	knownValues: readonly (infer K extends
-																		string)[];
-															  }
-															? K | (string & {})
-															: string
-													: T extends { type: "bytes" }
-														? Uint8Array
-														: T extends { type: "cid-link" }
-															? string
-															: T extends { type: "blob" }
-																? Blob
-																: never;
+	: T extends { type: "query" }
+		? InferQuery<T>
+		: T extends { type: "procedure" }
+			? InferProcedure<T>
+			: T extends { type: "subscription" }
+				? InferSubscription<T>
+				: T extends { type: "object" }
+					? InferObject<T>
+					: T extends { type: "array" }
+						? InferArray<T>
+						: T extends { type: "params" }
+							? InferParams<T>
+							: T extends { type: "permission-set" }
+								? InferPermissionSet<T>
+								: T extends { type: "union" }
+									? InferUnion<T>
+									: T extends { type: "token" }
+										? InferToken<T>
+										: T extends { type: "ref" }
+											? InferRef<T>
+											: T extends { type: "unknown" }
+												? unknown
+												: T extends { type: "null" }
+													? null
+													: T extends { type: "boolean" }
+														? boolean
+														: T extends { type: "integer" }
+															? number
+															: T extends { type: "string" }
+																? T extends {
+																		enum: readonly (infer E extends string)[];
+																	}
+																	? E
+																	: T extends {
+																				knownValues: readonly (infer K extends
+																					string)[];
+																		  }
+																		? K | (string & {})
+																		: string
+																: T extends { type: "bytes" }
+																	? Uint8Array
+																	: T extends { type: "cid-link" }
+																		? string
+																		: T extends { type: "blob" }
+																			? Blob
+																			: never;
 
 type InferToken<T> = T extends { enum: readonly (infer U)[] } ? U : string;
 
@@ -170,6 +176,32 @@ type InferRecord<T> = T extends { record: infer R }
 			? InferUnion<R>
 			: unknown
 	: unknown;
+
+type InferBody<T> = T extends { schema: infer S }
+	? S extends { type: "object" }
+		? InferObject<S>
+		: S extends { type: "union" }
+			? InferUnion<S>
+			: unknown
+	: unknown;
+
+type InferQuery<T> = Prettify<
+	(T extends { parameters: infer P } ? { parameters: InferType<P> } : {}) &
+		(T extends { output: infer O } ? { output: InferBody<O> } : {})
+>;
+
+type InferProcedure<T> = Prettify<
+	(T extends { parameters: infer P } ? { parameters: InferType<P> } : {}) &
+		(T extends { input: infer I } ? { input: InferBody<I> } : {}) &
+		(T extends { output: infer O } ? { output: InferBody<O> } : {})
+>;
+
+type InferSubscription<T> = Prettify<
+	(T extends { parameters: infer P } ? { parameters: InferType<P> } : {}) &
+		(T extends { message: { schema: infer S } }
+			? { message: InferType<S> }
+			: {})
+>;
 
 /**
  * Recursively replaces stub references in a type with their actual definitions.

--- a/packages/prototypey/core/tests/from-json-infer.test.ts
+++ b/packages/prototypey/core/tests/from-json-infer.test.ts
@@ -634,6 +634,210 @@ test("fromJSON InferRecord handles record with object schema", () => {
 });
 
 // ============================================================================
+// QUERY TYPE TESTS
+// ============================================================================
+
+test("fromJSON InferQuery handles query with parameters and output", () => {
+	const lexicon = fromJSON({
+		id: "app.bsky.graph.getStarterPack",
+		defs: {
+			main: {
+				type: "query",
+				parameters: {
+					type: "params",
+					required: ["starterPack"],
+					properties: {
+						starterPack: { type: "string", format: "at-uri" },
+					},
+				},
+				output: {
+					encoding: "application/json",
+					schema: {
+						type: "object",
+						required: ["starterPack"],
+						properties: {
+							starterPack: {
+								type: "ref",
+								ref: "app.bsky.graph.defs#starterPackView",
+							},
+						},
+					},
+				},
+			},
+		},
+	});
+
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "app.bsky.graph.getStarterPack"
+  parameters: { starterPack: string }
+  output: {
+    starterPack: {
+      [x: string]: unknown
+      $type: "app.bsky.graph.defs#starterPackView"
+    }
+  }
+}`);
+});
+
+test("fromJSON InferQuery handles query with only output", () => {
+	const lexicon = fromJSON({
+		id: "com.example.getStatus",
+		defs: {
+			main: {
+				type: "query",
+				output: {
+					encoding: "application/json",
+					schema: {
+						type: "object",
+						required: ["status"],
+						properties: {
+							status: { type: "string" },
+							uptime: { type: "integer" },
+						},
+					},
+				},
+			},
+		},
+	});
+
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "com.example.getStatus"
+  output: { uptime?: number | undefined; status: string }
+}`);
+});
+
+test("fromJSON InferQuery handles query with local ref in output", () => {
+	const lexicon = fromJSON({
+		id: "com.example.getUser",
+		defs: {
+			profile: {
+				type: "object",
+				properties: {
+					name: { type: "string" },
+					bio: { type: "string" },
+				},
+				required: ["name"],
+			},
+			main: {
+				type: "query",
+				parameters: {
+					type: "params",
+					required: ["did"],
+					properties: {
+						did: { type: "string", format: "did" },
+					},
+				},
+				output: {
+					encoding: "application/json",
+					schema: {
+						type: "object",
+						required: ["profile"],
+						properties: {
+							profile: { type: "ref", ref: "#profile" },
+						},
+					},
+				},
+			},
+		},
+	});
+
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "com.example.getUser"
+  parameters: { did: string }
+  output: {
+    profile: {
+      bio?: string | undefined
+      name: string
+      $type: "#profile"
+    }
+  }
+}`);
+});
+
+// ============================================================================
+// PROCEDURE TYPE TESTS
+// ============================================================================
+
+test("fromJSON InferProcedure handles procedure with input and output", () => {
+	const lexicon = fromJSON({
+		id: "com.example.createPost",
+		defs: {
+			main: {
+				type: "procedure",
+				input: {
+					encoding: "application/json",
+					schema: {
+						type: "object",
+						required: ["text"],
+						properties: {
+							text: { type: "string" },
+						},
+					},
+				},
+				output: {
+					encoding: "application/json",
+					schema: {
+						type: "object",
+						required: ["uri", "cid"],
+						properties: {
+							uri: { type: "string", format: "at-uri" },
+							cid: { type: "string" },
+						},
+					},
+				},
+			},
+		},
+	});
+
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "com.example.createPost"
+  input: { text: string }
+  output: { cid: string; uri: string }
+}`);
+});
+
+// ============================================================================
+// SUBSCRIPTION TYPE TESTS
+// ============================================================================
+
+test("fromJSON InferSubscription handles subscription with message", () => {
+	const lexicon = fromJSON({
+		id: "com.example.subscribe",
+		defs: {
+			main: {
+				type: "subscription",
+				parameters: {
+					type: "params",
+					properties: {
+						cursor: { type: "integer" },
+					},
+				},
+				message: {
+					schema: {
+						type: "union",
+						refs: ["com.example.event#create", "com.example.event#delete"],
+					},
+				},
+			},
+		},
+	});
+
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "com.example.subscribe"
+  parameters: { cursor?: number | undefined }
+  message:
+    | {
+        [x: string]: unknown
+        $type: "com.example.event#create"
+      }
+    | {
+        [x: string]: unknown
+        $type: "com.example.event#delete"
+      }
+}`);
+});
+
+// ============================================================================
 // NESTED OBJECTS TESTS
 // ============================================================================
 

--- a/packages/prototypey/core/tests/infer.bench.ts
+++ b/packages/prototypey/core/tests/infer.bench.ts
@@ -348,6 +348,57 @@ bench("fromJSON infer with app.bsky.feed.defs lexicon", () => {
 	return schema["~infer"];
 }).types([587, "instantiations"]);
 
+bench("infer with query endpoint", () => {
+	const schema = lx.lexicon("app.bsky.graph.getStarterPack", {
+		main: lx.query({
+			parameters: lx.params({
+				starterPack: lx.string({ required: true, format: "at-uri" }),
+			}),
+			output: {
+				encoding: "application/json",
+				schema: lx.object({
+					starterPack: lx.ref("app.bsky.graph.defs#starterPackView", {
+						required: true,
+					}),
+				}),
+			},
+		}),
+	});
+	return schema["~infer"];
+}).types([1137, "instantiations"]);
+
+bench("fromJSON infer with query endpoint", () => {
+	const schema = fromJSON({
+		id: "app.bsky.graph.getStarterPack",
+		defs: {
+			main: {
+				type: "query",
+				parameters: {
+					type: "params",
+					required: ["starterPack"],
+					properties: {
+						starterPack: { type: "string", format: "at-uri" },
+					},
+				},
+				output: {
+					encoding: "application/json",
+					schema: {
+						type: "object",
+						required: ["starterPack"],
+						properties: {
+							starterPack: {
+								type: "ref",
+								ref: "app.bsky.graph.defs#starterPackView",
+							},
+						},
+					},
+				},
+			},
+		},
+	});
+	return schema["~infer"];
+}).types([343, "instantiations"]);
+
 bench("infer with simple permission set", () => {
 	const schema = lx.lexicon("com.example.authCore", {
 		main: lx.permissionSet({

--- a/packages/prototypey/core/tests/infer.test.ts
+++ b/packages/prototypey/core/tests/infer.test.ts
@@ -619,6 +619,173 @@ test("InferRecord handles record with object schema", () => {
 });
 
 // ============================================================================
+// QUERY TYPE TESTS
+// ============================================================================
+
+test("InferQuery handles query with parameters and output", () => {
+	const lexicon = lx.lexicon("app.bsky.graph.getStarterPack", {
+		main: lx.query({
+			parameters: lx.params({
+				starterPack: lx.string({ required: true, format: "at-uri" }),
+			}),
+			output: {
+				encoding: "application/json",
+				schema: lx.object({
+					starterPack: lx.ref("app.bsky.graph.defs#starterPackView", {
+						required: true,
+					}),
+				}),
+			},
+		}),
+	});
+
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "app.bsky.graph.getStarterPack"
+  parameters: { starterPack: string }
+  output: {
+    starterPack?:
+      | {
+          [x: string]: unknown
+          $type: "app.bsky.graph.defs#starterPackView"
+        }
+      | undefined
+  }
+}`);
+});
+
+test("InferQuery handles query with only output", () => {
+	const lexicon = lx.lexicon("com.example.getStatus", {
+		main: lx.query({
+			output: {
+				encoding: "application/json",
+				schema: lx.object({
+					status: lx.string({ required: true }),
+					uptime: lx.integer(),
+				}),
+			},
+		}),
+	});
+
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "com.example.getStatus"
+  output: { uptime?: number | undefined; status: string }
+}`);
+});
+
+test("InferQuery handles query with only parameters", () => {
+	const lexicon = lx.lexicon("com.example.ping", {
+		main: lx.query({
+			parameters: lx.params({
+				echo: lx.string(),
+			}),
+		}),
+	});
+
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "com.example.ping"
+  parameters: { echo?: string | undefined }
+}`);
+});
+
+test("InferQuery handles query with local ref in output", () => {
+	const lexicon = lx.lexicon("com.example.getUser", {
+		profile: lx.object({
+			name: lx.string({ required: true }),
+			bio: lx.string(),
+		}),
+		main: lx.query({
+			parameters: lx.params({
+				did: lx.string({ required: true, format: "did" }),
+			}),
+			output: {
+				encoding: "application/json",
+				schema: lx.object({
+					profile: lx.ref("#profile", { required: true }),
+				}),
+			},
+		}),
+	});
+
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "com.example.getUser"
+  parameters: { did: string }
+  output: {
+    profile?:
+      | {
+          bio?: string | undefined
+          name: string
+          $type: "#profile"
+        }
+      | undefined
+  }
+}`);
+});
+
+// ============================================================================
+// PROCEDURE TYPE TESTS
+// ============================================================================
+
+test("InferProcedure handles procedure with input and output", () => {
+	const lexicon = lx.lexicon("com.example.createPost", {
+		main: lx.procedure({
+			input: {
+				encoding: "application/json",
+				schema: lx.object({
+					text: lx.string({ required: true }),
+				}),
+			},
+			output: {
+				encoding: "application/json",
+				schema: lx.object({
+					uri: lx.string({ required: true, format: "at-uri" }),
+					cid: lx.string({ required: true }),
+				}),
+			},
+		}),
+	});
+
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "com.example.createPost"
+  input: { text: string }
+  output: { cid: string; uri: string }
+}`);
+});
+
+// ============================================================================
+// SUBSCRIPTION TYPE TESTS
+// ============================================================================
+
+test("InferSubscription handles subscription with parameters and message", () => {
+	const lexicon = lx.lexicon("com.example.subscribe", {
+		main: lx.subscription({
+			parameters: lx.params({
+				cursor: lx.integer(),
+			}),
+			message: {
+				schema: lx.union([
+					"com.example.event#create",
+					"com.example.event#delete",
+				]),
+			},
+		}),
+	});
+
+	attest(lexicon["~infer"]).type.toString.snap(`{
+  $type: "com.example.subscribe"
+  parameters: { cursor?: number | undefined }
+  message:
+    | {
+        [x: string]: unknown
+        $type: "com.example.event#create"
+      }
+    | {
+        [x: string]: unknown
+        $type: "com.example.event#delete"
+      }
+}`);
+});
+
+// ============================================================================
 // NESTED OBJECTS TESTS
 // ============================================================================
 


### PR DESCRIPTION
Hey @tylersayshi, I needed inference for `query`, `procedure`, and `subscription` types, so thought I'd give it a crack.

I'd appreciate feedback!

```ts
const getUser = lx.lexicon("com.example.getUser", {
	main: lx.query({
		parameters: lx.params({
			did: lx.string({ required: true, format: "did" }),
		}),
		output: {
			encoding: "application/json",
			schema: lx.object({
				name: lx.string({ required: true }),
				bio: lx.string(),
			}),
		},
	}),
});

type GetUser = (typeof getUser)["~infer"];
// {
//   $type: "com.example.getUser"
//   parameters: { did: string }
//   output: { name: string; bio?: string | undefined }
// }
```