### PR TITLE
Infer blob lexicon type as BlobRef instead of browser Blob

### DIFF
--- a/.changeset/blob-ref-type.md
+++ b/.changeset/blob-ref-type.md
@@ -1,0 +1,20 @@
+---
+"prototypey": minor
+---
+
+Infer `lx.blob(...)` as `BlobRef` instead of the browser's `Blob`.
+
+The browser's `Blob` describes binary data on the client, not the AT Protocol blob shape that actually appears in records over the wire. Lexicons using `lx.blob(...)` now infer to a locally-defined `BlobRef`:
+
+```ts
+type BlobRef = {
+	$type: "blob";
+	ref: { $link: string } | Cid;
+	mimeType: string;
+	size: number;
+};
+```
+
+This mirrors `BlobRef` from [`@atproto/api`](https://github.com/bluesky-social/atproto/tree/main/packages/api) / [`@atproto/lex-data`](https://github.com/bluesky-social/atproto/tree/main/packages/lex-data) without taking either as a dependency. `BlobRef` is exported from the package root for direct use.
+
+**Breaking:** code that previously read blob fields as `Blob` (e.g. calling `.arrayBuffer()` on them) will need to update to the `BlobRef` shape.

--- a/packages/prototypey/core/infer.ts
+++ b/packages/prototypey/core/infer.ts
@@ -10,6 +10,28 @@ import { Prettify } from "./type-utils.ts";
 type NestedObjectError =
 	'[Nested objects are not supported in lexicon definitions. Per the Lexicon spec, objects can be "nested inside other definitions by reference" (https://atproto.com/specs/lexicon#object). Define each object in its own lexicon def and use lx.ref() instead.]';
 
+/**
+ * Minimal structural CID, compatible with the `CID` class from
+ * [`multiformats`](https://github.com/multiformats/js-multiformats) and the `Cid` interface from
+ * [`@atproto/lex-data`](https://github.com/bluesky-social/atproto/tree/main/packages/lex-data).
+ */
+type Cid = { readonly bytes: Uint8Array };
+
+/**
+ * AT Protocol blob reference. Mirrors `BlobRef` from
+ * [`@atproto/api`](https://github.com/bluesky-social/atproto/tree/main/packages/api) /
+ * [`@atproto/lex-data`](https://github.com/bluesky-social/atproto/tree/main/packages/lex-data),
+ * but defined locally to avoid pulling in those packages as dependencies.
+ *
+ * @see https://atproto.com/specs/data-model#blob-type
+ */
+export type BlobRef = {
+	$type: "blob";
+	ref: { $link: string } | Cid;
+	mimeType: string;
+	size: number;
+};
+
 /** Resolves property type, returning NestedObjectError for inline nested objects. */
 type InferPropertyType<T> = T extends { type: "object" }
 	? NestedObjectError
@@ -61,7 +83,7 @@ type InferType<T> = T extends { type: "record" }
 																	: T extends { type: "cid-link" }
 																		? string
 																		: T extends { type: "blob" }
-																			? Blob
+																			? BlobRef
 																			: never;
 
 type InferToken<T> = T extends { enum: readonly (infer U)[] } ? U : string;
@@ -223,7 +245,7 @@ type ReplaceRefsInType<T, Defs, Visited = never> =
 			: // Reference not found in definitions
 				`[Reference not found: #${DefName}]`
 		: // Handle arrays (but not Uint8Array or other typed arrays)
-			T extends Uint8Array | Blob
+			T extends Uint8Array | BlobRef
 			? T
 			: T extends readonly (infer Item)[]
 				? ReplaceRefsInType<Item, Defs, Visited>[]

--- a/packages/prototypey/core/main.ts
+++ b/packages/prototypey/core/main.ts
@@ -1,3 +1,3 @@
 export { lx, fromJSON } from "./lib.ts";
-export { type Infer } from "./infer.ts";
+export { type Infer, type BlobRef } from "./infer.ts";
 export type * from "@atproto/lexicon";

--- a/packages/prototypey/core/tests/from-json-infer.test.ts
+++ b/packages/prototypey/core/tests/from-json-infer.test.ts
@@ -215,7 +215,7 @@ test("fromJSON InferType handles blob primitive", () => {
 	});
 
 	attest(lexicon["~infer"]).type.toString.snap(
-		'{ $type: "test.blob"; image?: Blob | undefined }',
+		'{ $type: "test.blob"; image?: BlobRef | undefined }',
 	);
 });
 

--- a/packages/prototypey/core/tests/infer.test.ts
+++ b/packages/prototypey/core/tests/infer.test.ts
@@ -248,7 +248,7 @@ test("InferType handles blob primitive", () => {
 	});
 
 	attest(lexicon["~infer"]).type.toString.snap(
-		'{ $type: "test.blob"; image?: Blob | undefined }',
+		'{ $type: "test.blob"; image?: BlobRef | undefined }',
 	);
 });
 


### PR DESCRIPTION
Hey @tylersayshi — I noticed that prototypey uses the browser's `Blob` type for blobs, which means that well-structured [records with blobs](https://atproto.com/specs/data-model#blob-type) don't meet the inferred type (`{ $type, ref, mimeType, size }` doesn't meet `Blob`).

This change replaces `Blob` type with a `BlobRef` type added (with `@see` references) which mirrors the type from `@atproto/api`/`@atproto/lex-data` (and, given how simple it is, I'd imagine elsewhere too).

I've called this  a breaking change, but I'm not sure that the previous inference would have been useful to anyone.